### PR TITLE
Update INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -50,6 +50,7 @@ you want to change it or regenerate 'configure' using a newer version of
    The simplest way to compile this package is:
 
   1. 'cd' to the directory containing the package's source code and type
+     './autogen.sh'. The configure script will be created. Then type
      './configure' to configure the package for your system.
 
      Running 'configure' might take a while.  While running, it prints


### PR DESCRIPTION
Initially, there is no '.configure' file which leads to 'bash: ./configure: No such file or directory'. This PR adds one step to generate the configure script.